### PR TITLE
Add missing media types on Updates

### DIFF
--- a/src/Ipalaus/Buffer/Update.php
+++ b/src/Ipalaus/Buffer/Update.php
@@ -94,7 +94,7 @@ class Update
      */
     public function addMedia($key, $value)
     {
-        $available = array('link', 'description', 'picture', 'thumbnail');
+        $available = array('link', 'description', 'title', 'picture', 'photo', 'thumbnail');
 
         // accept only valid types for media
         if ( ! in_array($key, $available)) {


### PR DESCRIPTION
Available media type on Updates (https://buffer.com/developers/api/updates#updatescreate)
- link
- description
- title
- picture
- photo
- thumbnail
